### PR TITLE
Fix BadgeView Count Font Alignment

### DIFF
--- a/app/src/main/java/me/tylerbwong/stack/ui/owners/BadgeView.kt
+++ b/app/src/main/java/me/tylerbwong/stack/ui/owners/BadgeView.kt
@@ -69,9 +69,9 @@ class BadgeView : View {
             var badgeCount = 0
 
             // add space for each badge
-            listOf(it.gold, it.silver, it.bronze).forEach {
-                if (it > 0) {
-                    idealWidth += iconHeight + iconLabelPadding + textPaint.measureText(it.toString())
+            listOf(it.gold, it.silver, it.bronze).forEach { count ->
+                if (count > 0) {
+                    idealWidth += iconHeight + iconLabelPadding + textPaint.measureText(count.toString())
                     addPadding = true
                     badgeCount += 1
                 }
@@ -112,7 +112,7 @@ class BadgeView : View {
                     val amountString = amount.toString()
                     posX += iconRadius + iconLabelPadding
                     textPaint.getTextBounds(amountString, 0, amountString.length, labelHelperRect)
-                    canvas.drawText(amountString, posX, canvasHeight - paddingBottom - textPaint.fontMetrics.descent, textPaint)
+                    canvas.drawText(amountString, posX, canvasHeight - paddingBottom - textPaint.fontMetrics.bottom, textPaint)
                     posX += textPaint.measureText(amountString) + badgePadding
                 }
             }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,5 +6,4 @@
     <dimen name="item_spacing_question_detail">16dp</dimen>
     <dimen name="divider_height">1px</dimen>
     <dimen name="keyline_1">72dp</dimen>
-    <dimen name="small_icon_size">4dp</dimen>
 </resources>


### PR DESCRIPTION
In order to make sure the badge counts were center aligned with their badges we need to use `fontMetrics.bottom` instead of `fontMetrics.descent` for an accurate y-position when drawing the label. Using `fontMetrics.bottom` for this calculation is safe since number characters never get drawn below the baseline.