### PR TITLE
Fix Answer FAB Visibility

### DIFF
--- a/app/src/main/java/me/tylerbwong/stack/ui/questions/detail/QuestionDetailFragment.kt
+++ b/app/src/main/java/me/tylerbwong/stack/ui/questions/detail/QuestionDetailFragment.kt
@@ -6,7 +6,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -25,7 +25,7 @@ import me.tylerbwong.stack.ui.utils.showSnackbar
 
 class QuestionDetailFragment : Fragment(R.layout.question_detail_fragment) {
 
-    private val viewModel by viewModels<QuestionDetailMainViewModel>()
+    private lateinit var viewModel: QuestionDetailMainViewModel
     private val adapter = DynamicViewAdapter()
     private var snackbar: Snackbar? = null
 
@@ -36,6 +36,8 @@ class QuestionDetailFragment : Fragment(R.layout.question_detail_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        viewModel = ViewModelProvider(requireActivity()).get(QuestionDetailMainViewModel::class.java)
 
         viewModel.refreshing.observe(this) {
             refreshLayout.isRefreshing = it

--- a/app/src/main/java/me/tylerbwong/stack/ui/questions/detail/post/PostAnswerFragment.kt
+++ b/app/src/main/java/me/tylerbwong/stack/ui/questions/detail/post/PostAnswerFragment.kt
@@ -11,6 +11,7 @@ import android.view.View
 import androidx.core.widget.NestedScrollView.OnScrollChangeListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.observe
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
@@ -30,7 +31,7 @@ import me.tylerbwong.stack.ui.utils.showSnackbar
 class PostAnswerFragment : Fragment(R.layout.post_answer_fragment) {
 
     private val viewModel by viewModels<PostAnswerViewModel>()
-    private val mainViewModel by viewModels<QuestionDetailMainViewModel>()
+    private lateinit var mainViewModel: QuestionDetailMainViewModel
     private var menu: Menu? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,6 +40,8 @@ class PostAnswerFragment : Fragment(R.layout.post_answer_fragment) {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        mainViewModel = ViewModelProvider(requireActivity()).get(QuestionDetailMainViewModel::class.java)
 
         mainViewModel.clearFields.observe(this) { clearFields() }
 


### PR DESCRIPTION
Using the `viewModel` delegate does not make sure the view model is tied to a specific scope. In order to specify child `Fragment`s to use the correct view model, `ViewModelProvider` needs to be used, otherwise multiple instances will be created.