### PR TITLE
Temporarily remove local persistence usage

### DIFF
--- a/app/src/main/java/me/tylerbwong/stack/data/auth/AuthRepository.kt
+++ b/app/src/main/java/me/tylerbwong/stack/data/auth/AuthRepository.kt
@@ -6,13 +6,9 @@ import me.tylerbwong.stack.data.model.User
 import me.tylerbwong.stack.data.network.ServiceProvider
 import me.tylerbwong.stack.data.network.service.AuthService
 import me.tylerbwong.stack.data.network.service.UserService
-import me.tylerbwong.stack.data.persistence.StackDatabase
-import me.tylerbwong.stack.data.persistence.dao.UserDao
-import me.tylerbwong.stack.data.toUserEntity
 import timber.log.Timber
 
 class AuthRepository(
-    private val userDao: UserDao = StackDatabase.getInstance().getUserDao(),
     private val userService: UserService = ServiceProvider.userService,
     private val authService: AuthService = ServiceProvider.authService,
     private val authStore: AuthStore = AuthStore
@@ -42,9 +38,7 @@ class AuthRepository(
     suspend fun getCurrentUser(): User? {
         return try {
             if (authStore.isAuthenticatedLiveData.value == true) {
-                userService.getCurrentUser().items.firstOrNull()?.also {
-                    userDao.insert(listOf(it.toUserEntity()))
-                }
+                userService.getCurrentUser().items.firstOrNull()
             } else {
                 null
             }

--- a/app/src/main/java/me/tylerbwong/stack/data/repository/QuestionRepository.kt
+++ b/app/src/main/java/me/tylerbwong/stack/data/repository/QuestionRepository.kt
@@ -1,62 +1,16 @@
 package me.tylerbwong.stack.data.repository
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import me.tylerbwong.stack.data.model.Question
 import me.tylerbwong.stack.data.model.Sort
 import me.tylerbwong.stack.data.network.ServiceProvider
-import me.tylerbwong.stack.data.persistence.StackDatabase
-import me.tylerbwong.stack.data.persistence.entity.QuestionEntity
-import me.tylerbwong.stack.data.persistence.entity.UserEntity
-import me.tylerbwong.stack.data.toQuestion
-import me.tylerbwong.stack.data.toQuestionEntity
-import me.tylerbwong.stack.data.toUserEntity
 
-class QuestionRepository(private val stackDatabase: StackDatabase = StackDatabase.getInstance()) {
-
-    private val questionDao by lazy { stackDatabase.getQuestionDao() }
-    private val userDao by lazy { stackDatabase.getUserDao() }
+class QuestionRepository {
 
     suspend fun getQuestions(@Sort sort: String): List<Question> {
-        getQuestionsFromNetwork(sort)
-        return withContext(Dispatchers.IO) { getQuestionsFromDb(sort) }
-    }
-
-    private suspend fun getQuestionsFromDb(@Sort sort: String): List<Question> {
-        return questionDao.get(sort)
-            .map { questionEntity ->
-                questionEntity.toQuestion(
-                    userDao.get(questionEntity.owner),
-                    questionEntity.lastEditor?.let { userDao.get(it) }
-                )
-            }
+        return getQuestionsFromNetwork(sort)
     }
 
     private suspend fun getQuestionsFromNetwork(@Sort sort: String): List<Question> {
-        return ServiceProvider.questionService.getQuestions(sort = sort)
-            .items
-            .also { withContext(Dispatchers.IO) { saveQuestions(it, sort) } }
-    }
-
-    private suspend fun saveQuestions(questions: List<Question>, @Sort sortString: String) {
-        val userEntities = mutableListOf<UserEntity>()
-        val questionEntities = mutableListOf<QuestionEntity>()
-        questions.forEach { question ->
-            userEntities.add(question.owner.toUserEntity())
-            question.lastEditor?.let { userEntities.add(it.toUserEntity()) }
-            questionEntities.add(question.toQuestionEntity(sortString))
-        }
-        updateQuestionsAndUsers(questionEntities, userEntities, sortString)
-    }
-
-    private suspend fun updateQuestionsAndUsers(
-        questions: List<QuestionEntity>,
-        users: List<UserEntity>,
-        sortString: String
-    ) {
-        // TODO delete old users
-        questionDao.delete(sortString)
-        userDao.insert(users)
-        questionDao.insert(questions)
+        return ServiceProvider.questionService.getQuestions(sort = sort).items
     }
 }

--- a/app/src/test/java/me/tylerbwong/stack/data/auth/AuthRepositoryTest.kt
+++ b/app/src/test/java/me/tylerbwong/stack/data/auth/AuthRepositoryTest.kt
@@ -14,9 +14,11 @@ import me.tylerbwong.stack.data.persistence.dao.UserDao
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
@@ -40,7 +42,7 @@ class AuthRepositoryTest : BaseTest() {
 
     @Before
     fun setUp() {
-        repository = AuthRepository(userDao, userService, authService)
+        repository = AuthRepository(userService, authService)
     }
 
     @Test
@@ -93,9 +95,9 @@ class AuthRepositoryTest : BaseTest() {
                 StackResponse(listOf(testUser), false)
             )
             AuthStore.setAccessToken(testUri)
-            repository.getCurrentUser()
+            assertEquals(testUser, repository.getCurrentUser())
             verify(userService).getCurrentUser(any(), any(), any())
-            verify(userDao).insert(any())
+//            verify(userDao).insert(any())
         }
     }
 
@@ -132,16 +134,17 @@ class AuthRepositoryTest : BaseTest() {
     }
 
     @Test
-    fun `getCurrentUser with throwing db call returns null`() {
+    @Ignore("AuthRepository no longer stores the current user in the db")
+    fun `getCurrentUser with throwing db call still returns the user from the service`() {
         runBlocking {
             whenever(userService.getCurrentUser(any(), any(), any())).thenReturn(
                 StackResponse(listOf(testUser), false)
             )
             whenever(userDao.insert(any())).thenThrow(IllegalStateException("Could not insert"))
             AuthStore.setAccessToken(testUri)
-            assertNull(repository.getCurrentUser())
+            assertEquals(testUser, repository.getCurrentUser())
             verify(userService).getCurrentUser(any(), any(), any())
-            verify(userDao).insert(any())
+//            verify(userDao).insert(any())
         }
     }
 


### PR DESCRIPTION
ATM questions and users are stored in the database; however, it doesn't provide any utility and isn't used to show offline data. 
Temporarily removes storing data in the db until rethink how we want to use it.