### PR TITLE
Store and override deep link site within deep link activities

### DIFF
--- a/app/src/main/kotlin/me/tylerbwong/stack/data/DeepLinker.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/DeepLinker.kt
@@ -19,7 +19,7 @@ sealed class DeepLinkResult {
 }
 
 @Singleton
-class DeepLinker @Inject constructor(private val siteStore: SiteStore) {
+class DeepLinker @Inject constructor() {
     private enum class ResolvedPath(vararg val paths: String) {
         AUTH("/auth/redirect"),
         QUESTIONS_BY_TAG("/questions/tagged/"),
@@ -39,21 +39,20 @@ class DeepLinker @Inject constructor(private val siteStore: SiteStore) {
         return when (ResolvedPath.fromPath(path)) {
             AUTH -> DeepLinkResult.RequestingAuth
             QUESTIONS_BY_TAG -> {
-                siteStore.deepLinkSite = site
                 DeepLinkResult.Success(
                     QuestionsActivity.makeIntentForKey(
                         context,
                         TAGS,
-                        uri.lastPathSegment ?: ""
+                        uri.lastPathSegment ?: "",
+                        deepLinkSite = site
                     )
                 )
             }
             QUESTION_DETAILS -> {
-                siteStore.deepLinkSite = site
                 // Format is /questions/{id}/title so get the second segment
                 val id = uri.pathSegments.getOrNull(1)?.toIntOrNull()
                     ?: return DeepLinkResult.PathNotSupportedError
-                DeepLinkResult.Success(QuestionDetailActivity.makeIntent(context, id))
+                DeepLinkResult.Success(QuestionDetailActivity.makeIntent(context, id, deepLinkSite = site))
             }
             else -> DeepLinkResult.PathNotSupportedError
         }

--- a/app/src/main/kotlin/me/tylerbwong/stack/ui/BaseActivity.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/ui/BaseActivity.kt
@@ -8,7 +8,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.viewbinding.ViewBinding
 import dev.chrisbanes.insetter.applySystemGestureInsetsToPadding
 import me.tylerbwong.stack.R
+import me.tylerbwong.stack.data.SiteStore
 import me.tylerbwong.stack.ui.theme.ThemeManager
+import javax.inject.Inject
 
 abstract class BaseActivity<T : ViewBinding>(
     // TODO Enable when Hilt supports default constructor arguments
@@ -16,6 +18,8 @@ abstract class BaseActivity<T : ViewBinding>(
 ) : AppCompatActivity() {
 
     protected lateinit var binding: T
+
+    @Inject lateinit var siteStore: SiteStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         ThemeManager.injectTheme(this)
@@ -25,6 +29,12 @@ abstract class BaseActivity<T : ViewBinding>(
             setContentView(binding.root)
         }
         applyFullscreenWindowInsets()
+        overrideDeepLinkSite()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        overrideDeepLinkSite()
     }
 
     @Suppress("deprecation") // TODO Update to Android R APIs
@@ -35,5 +45,13 @@ abstract class BaseActivity<T : ViewBinding>(
             View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
         val appBar = findViewById(R.id.appBar) ?: rootLayout
         appBar?.applySystemGestureInsetsToPadding(top = true)
+    }
+
+    private fun overrideDeepLinkSite() {
+        intent.getStringExtra(DEEP_LINK_SITE)?.let { siteStore.deepLinkSite = it }
+    }
+
+    companion object {
+        internal const val DEEP_LINK_SITE = "deep_link_site"
     }
 }

--- a/app/src/main/kotlin/me/tylerbwong/stack/ui/BaseActivity.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/ui/BaseActivity.kt
@@ -19,7 +19,8 @@ abstract class BaseActivity<T : ViewBinding>(
 
     protected lateinit var binding: T
 
-    @Inject lateinit var siteStore: SiteStore
+    @Inject
+    lateinit var siteStore: SiteStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         ThemeManager.injectTheme(this)

--- a/app/src/main/kotlin/me/tylerbwong/stack/ui/questions/QuestionsActivity.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/ui/questions/QuestionsActivity.kt
@@ -140,10 +140,12 @@ class QuestionsActivity : BaseActivity<ActivityQuestionsBinding>(
         fun makeIntentForKey(
             context: Context,
             page: QuestionPage,
-            key: String
+            key: String,
+            deepLinkSite: String? = null
         ) = Intent(context, QuestionsActivity::class.java)
             .putExtra(PAGE_EXTRA, page)
             .putExtra(KEY_EXTRA, key)
+            .putExtra(DEEP_LINK_SITE, deepLinkSite)
 
         fun startActivityForKey(context: Context, page: QuestionPage, key: String) {
             context.startActivity(makeIntentForKey(context, page, key))

--- a/app/src/main/kotlin/me/tylerbwong/stack/ui/questions/detail/QuestionDetailActivity.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/ui/questions/detail/QuestionDetailActivity.kt
@@ -150,10 +150,12 @@ class QuestionDetailActivity : BaseActivity<ActivityQuestionDetailBinding>(
         fun makeIntent(
             context: Context,
             id: Int,
-            isInAnswerMode: Boolean = false
+            isInAnswerMode: Boolean = false,
+            deepLinkSite: String? = null
         ) = Intent(context, QuestionDetailActivity::class.java)
             .putExtra(QUESTION_ID, id)
             .putExtra(IS_IN_ANSWER_MODE, isInAnswerMode)
+            .putExtra(DEEP_LINK_SITE, deepLinkSite)
 
         fun startActivity(context: Context, id: Int) {
             context.startActivity(makeIntent(context, id))

--- a/app/src/test/kotlin/me/tylerbwong/stack/data/DeepLinkerTest.kt
+++ b/app/src/test/kotlin/me/tylerbwong/stack/data/DeepLinkerTest.kt
@@ -10,7 +10,6 @@ import org.junit.Test
 class DeepLinkerTest : BaseTest() {
 
     private lateinit var deepLinker: DeepLinker
-    private lateinit var siteStore: SiteStore
 
     private val unsupportedDeepLinks = listOf(
         "https://stackoverflow.com/search?q=android+toolbar",
@@ -31,8 +30,7 @@ class DeepLinkerTest : BaseTest() {
 
     @Before
     fun setUp() {
-        siteStore = SiteStore(testSharedPreferences)
-        deepLinker = DeepLinker(siteStore)
+        deepLinker = DeepLinker()
     }
 
     @Test
@@ -64,6 +62,5 @@ class DeepLinkerTest : BaseTest() {
         val uri = Uri.parse("https://superuser.com/questions/tagged/android")
         val result = deepLinker.resolvePath(context, uri)
         assertTrue(result is DeepLinkResult.Success)
-        assertEquals("superuser.com", siteStore.site)
     }
 }


### PR DESCRIPTION
#### Description
Addresses Issue #94 by storing the deep link site within deeplink-able Activity intents and overriding the global deep link site in onCreate and onResume within the BaseActivity.

#### Checklist
- [x] I self reviewed the submitted code
- [x] I ran `./gradlew ktlintCheck detekt` before submitting this PR
- [x] I ran the app on a device/emulator or added unit tests to verify this change
