### PR TITLE
Fix Compounding WorkRequest Bug

### DIFF
--- a/app/src/main/kotlin/me/tylerbwong/stack/data/repository/QuestionRepository.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/repository/QuestionRepository.kt
@@ -84,22 +84,24 @@ class QuestionRepository @Inject constructor(
         return questionService.getBookmarks().items
     }
 
+    // TODO Enable Offline
     suspend fun syncBookmarks(): List<Question> {
-        return if (authRepository.isAuthenticated) {
-            try {
-                val bookmarks = questionService.getBookmarks().items
-                if (bookmarks.isNotEmpty()) {
-                    bookmarks.forEach { question -> saveQuestion(question) }
-                } else {
-                    clearAll()
-                }
-                bookmarks
-            } catch (ex: Exception) {
-                emptyList()
-            }
-        } else {
-            emptyList()
-        }
+//        return if (authRepository.isAuthenticated) {
+//            try {
+//                val bookmarks = questionService.getBookmarks().items
+//                if (bookmarks.isNotEmpty()) {
+//                    bookmarks.forEach { question -> saveQuestion(question) }
+//                } else {
+//                    clearAll()
+//                }
+//                bookmarks
+//            } catch (ex: Exception) {
+//                emptyList()
+//            }
+//        } else {
+//            emptyList()
+//        }
+        return emptyList()
     }
 
     suspend fun saveQuestion(question: Question): Boolean {
@@ -125,6 +127,7 @@ class QuestionRepository @Inject constructor(
     }
 
     /**
+     * TODO Enable Offline
      * TODO Figure out how to clear users safely
      * Need to look up if any remaining questions/answers still reference a user before removing it
      */

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/repository/QuestionRepository.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/repository/QuestionRepository.kt
@@ -1,7 +1,5 @@
 package me.tylerbwong.stack.data.repository
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import me.tylerbwong.stack.api.model.Answer
 import me.tylerbwong.stack.api.model.Question
 import me.tylerbwong.stack.api.model.Response
@@ -11,9 +9,7 @@ import me.tylerbwong.stack.data.auth.AuthRepository
 import me.tylerbwong.stack.data.persistence.dao.AnswerDao
 import me.tylerbwong.stack.data.persistence.dao.QuestionDao
 import me.tylerbwong.stack.data.persistence.dao.UserDao
-import me.tylerbwong.stack.data.toAnswer
 import me.tylerbwong.stack.data.toAnswerEntity
-import me.tylerbwong.stack.data.toQuestion
 import me.tylerbwong.stack.data.toQuestionEntity
 import me.tylerbwong.stack.data.toUserEntity
 import javax.inject.Inject
@@ -31,50 +27,61 @@ class QuestionRepository @Inject constructor(
         return getQuestionsFromNetwork(sort)
     }
 
+    // TODO Enable Offline
     suspend fun getQuestion(questionId: Int): Question {
+//        return if (authRepository.isAuthenticated) {
+//            withContext(Dispatchers.IO) {
+//                questionDao.get(questionId)?.let { entity ->
+//                    entity.toQuestion(
+//                        owner = userDao.get(entity.owner),
+//                        lastEditor = entity.lastEditor?.let { userDao.get(it) }
+//                    )
+//                }
+//            } ?: questionService.getQuestionDetailsAuth(questionId).items.first()
+//        } else {
+//            questionService.getQuestionDetails(questionId).items.first()
+//        }
         return if (authRepository.isAuthenticated) {
-            withContext(Dispatchers.IO) {
-                questionDao.get(questionId)?.let { entity ->
-                    entity.toQuestion(
-                        owner = userDao.get(entity.owner),
-                        lastEditor = entity.lastEditor?.let { userDao.get(it) }
-                    )
-                }
-            } ?: questionService.getQuestionDetailsAuth(questionId).items.first()
+            questionService.getQuestionDetailsAuth(questionId)
         } else {
-            questionService.getQuestionDetails(questionId).items.first()
-        }
+            questionService.getQuestionDetails(questionId)
+        }.items.first()
     }
 
+    // TODO Enable Offline
     suspend fun getQuestionAnswers(questionId: Int): List<Answer> {
-        val answerEntities = withContext(Dispatchers.IO) {
-            answerDao.getAnswersByQuestionId(questionId)
-        }
-        return if (answerEntities.isNotEmpty()) {
-            withContext(Dispatchers.IO) {
-                answerEntities.map { entity ->
-                    entity.toAnswer(
-                        owner = userDao.get(entity.owner),
-                        lastEditor = entity.lastEditor?.let { userDao.get(it) }
-                    )
-                }
-            }
-        } else {
-            safeCall { questionService.getQuestionAnswers(questionId) }
-        }.sortedBy { !it.isAccepted }
+//        val answerEntities = withContext(Dispatchers.IO) {
+//            answerDao.getAnswersByQuestionId(questionId)
+//        }
+//        return if (answerEntities.isNotEmpty()) {
+//            withContext(Dispatchers.IO) {
+//                answerEntities.map { entity ->
+//                    entity.toAnswer(
+//                        owner = userDao.get(entity.owner),
+//                        lastEditor = entity.lastEditor?.let { userDao.get(it) }
+//                    )
+//                }
+//            }
+//        } else {
+//            safeCall { questionService.getQuestionAnswers(questionId) }
+//        }.sortedBy { !it.isAccepted }
+        return safeCall { questionService.getQuestionAnswers(questionId) }
+            .sortedBy { !it.isAccepted }
     }
 
+    // TODO Enable Offline
     suspend fun getBookmarks(): List<Question> {
-        return withContext(Dispatchers.IO) {
-            syncBookmarks()
-            questionDao.getBookmarks()
-                .map { entity ->
-                    entity.toQuestion(
-                        owner = userDao.get(entity.owner),
-                        lastEditor = entity.lastEditor?.let { userDao.get(it) }
-                    )
-                }
-        }
+//        return withContext(Dispatchers.IO) {
+//            syncBookmarks()
+//            questionDao.getBookmarks()
+//                .map { entity ->
+//                    entity.toQuestion(
+//                        owner = userDao.get(entity.owner),
+//                        lastEditor = entity.lastEditor?.let { userDao.get(it) }
+//                    )
+//                }
+//        }
+        return questionService.getBookmarks().items
     }
 
     suspend fun syncBookmarks(): List<Question> {

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/BookmarksWorker.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/BookmarksWorker.kt
@@ -25,4 +25,8 @@ class BookmarksWorker @WorkerInject constructor(
         Timber.e(ex)
         Result.failure()
     }
+
+    companion object {
+        internal const val IDENTIFIER = "bookmarks-worker"
+    }
 }

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/SitesWorker.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/SitesWorker.kt
@@ -25,4 +25,8 @@ class SitesWorker @WorkerInject constructor(
         Timber.e(ex, "Failed to sync sites")
         Result.failure()
     }
+
+    companion object {
+        internal const val IDENTIFIER = "sites-worker"
+    }
 }

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/Work.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/Work.kt
@@ -1,0 +1,24 @@
+package me.tylerbwong.stack.data.work
+
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkRequest
+
+sealed class Work<T : WorkRequest>(
+    internal val identifier: String,
+    internal val workRequest: T
+) {
+    class OneTime(
+        identifier: String,
+        workRequest: OneTimeWorkRequest,
+        internal val existingWorkPolicy: ExistingWorkPolicy
+    ) : Work<OneTimeWorkRequest>(identifier, workRequest)
+
+    class Periodic(
+        identifier: String,
+        workRequest: PeriodicWorkRequest,
+        internal val existingWorkPolicy: ExistingPeriodicWorkPolicy
+    ) : Work<PeriodicWorkRequest>(identifier, workRequest)
+}

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkModule.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkModule.kt
@@ -2,9 +2,11 @@ package me.tylerbwong.stack.data.work
 
 import android.content.Context
 import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import dagger.Module
 import dagger.Provides
@@ -12,6 +14,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -37,18 +40,17 @@ class WorkModule {
     )
 
     // TODO Make interval configurable
-    // TODO Enable Offline
-//    @[Provides IntoSet]
-//    fun provideBookmarksWorkRequest(
-//        constraints: Constraints
-//    ): Work<*> = Work.Periodic(
-//        identifier = BookmarksWorker.IDENTIFIER,
-//        workRequest = PeriodicWorkRequestBuilder<BookmarksWorker>(8, TimeUnit.HOURS)
-//            .addTag(BookmarksWorker.IDENTIFIER)
-//            .setConstraints(constraints)
-//            .build(),
-//        existingWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
-//    )
+    @[Provides IntoSet]
+    fun provideBookmarksWorkRequest(
+        constraints: Constraints
+    ): Work<*> = Work.Periodic(
+        identifier = BookmarksWorker.IDENTIFIER,
+        workRequest = PeriodicWorkRequestBuilder<BookmarksWorker>(8, TimeUnit.HOURS)
+            .addTag(BookmarksWorker.IDENTIFIER)
+            .setConstraints(constraints)
+            .build(),
+        existingWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
+    )
 
     @[Provides Singleton]
     fun provideWorkerManager(

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkModule.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkModule.kt
@@ -2,11 +2,12 @@ package me.tylerbwong.stack.data.work
 
 import android.content.Context
 import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
-import androidx.work.WorkRequest
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -29,17 +30,27 @@ class WorkModule {
     @[Provides IntoSet]
     fun provideSitesWorkRequest(
         constraints: Constraints
-    ): WorkRequest = OneTimeWorkRequestBuilder<SitesWorker>()
-        .setConstraints(constraints)
-        .build()
+    ): Work<*> = Work.OneTime(
+        identifier = SitesWorker.IDENTIFIER,
+        workRequest = OneTimeWorkRequestBuilder<SitesWorker>()
+            .addTag(SitesWorker.IDENTIFIER)
+            .setConstraints(constraints)
+            .build(),
+        existingWorkPolicy = ExistingWorkPolicy.REPLACE
+    )
 
     // TODO Make interval configurable
     @[Provides IntoSet]
     fun provideBookmarksWorkRequest(
         constraints: Constraints
-    ): WorkRequest = PeriodicWorkRequestBuilder<BookmarksWorker>(8, TimeUnit.HOURS)
-        .setConstraints(constraints)
-        .build()
+    ): Work<*> = Work.Periodic(
+        identifier = BookmarksWorker.IDENTIFIER,
+        workRequest = PeriodicWorkRequestBuilder<BookmarksWorker>(8, TimeUnit.HOURS)
+            .addTag(BookmarksWorker.IDENTIFIER)
+            .setConstraints(constraints)
+            .build(),
+        existingWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
+    )
 
     @[Provides Singleton]
     fun provideWorkerManager(

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkModule.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkModule.kt
@@ -2,11 +2,9 @@ package me.tylerbwong.stack.data.work
 
 import android.content.Context
 import androidx.work.Constraints
-import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import dagger.Module
 import dagger.Provides
@@ -14,7 +12,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
-import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -40,17 +37,18 @@ class WorkModule {
     )
 
     // TODO Make interval configurable
-    @[Provides IntoSet]
-    fun provideBookmarksWorkRequest(
-        constraints: Constraints
-    ): Work<*> = Work.Periodic(
-        identifier = BookmarksWorker.IDENTIFIER,
-        workRequest = PeriodicWorkRequestBuilder<BookmarksWorker>(8, TimeUnit.HOURS)
-            .addTag(BookmarksWorker.IDENTIFIER)
-            .setConstraints(constraints)
-            .build(),
-        existingWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
-    )
+    // TODO Enable Offline
+//    @[Provides IntoSet]
+//    fun provideBookmarksWorkRequest(
+//        constraints: Constraints
+//    ): Work<*> = Work.Periodic(
+//        identifier = BookmarksWorker.IDENTIFIER,
+//        workRequest = PeriodicWorkRequestBuilder<BookmarksWorker>(8, TimeUnit.HOURS)
+//            .addTag(BookmarksWorker.IDENTIFIER)
+//            .setConstraints(constraints)
+//            .build(),
+//        existingWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
+//    )
 
     @[Provides Singleton]
     fun provideWorkerManager(

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
@@ -18,7 +18,7 @@ class WorkScheduler @Inject constructor(
      * requests.
      */
     fun schedule(lifecycleOwner: LifecycleOwner) {
-        val validWorkRequest = workRequests.firstOrNull() ?: return
+        val validWorkRequest = workRequests.firstOrNull { it is Work.Periodic } ?: return
         val workInfoLiveData = workManager.getWorkInfosForUniqueWorkLiveData(
             validWorkRequest.identifier
         )

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
@@ -18,7 +18,10 @@ class WorkScheduler @Inject constructor(
      * requests.
      */
     fun schedule(lifecycleOwner: LifecycleOwner) {
-        val validWorkRequest = workRequests.firstOrNull { it is Work.Periodic } ?: return
+        // TODO Delete this once enough people are on the new version
+        val validWorkRequest = workRequests.find {
+            it.identifier == BookmarksWorker.IDENTIFIER
+        } ?: return
         val workInfoLiveData = workManager.getWorkInfosForUniqueWorkLiveData(
             validWorkRequest.identifier
         )
@@ -27,6 +30,7 @@ class WorkScheduler @Inject constructor(
                 workManager.cancelAllWork()
             }
             scheduleNewWork()
+            workInfoLiveData.removeObservers(lifecycleOwner) // Only want to listen once
         }
     }
 

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
@@ -19,11 +19,8 @@ class WorkScheduler @Inject constructor(
      */
     fun schedule(lifecycleOwner: LifecycleOwner) {
         // TODO Delete this once enough people are on the new version
-        val validWorkRequest = workRequests.find {
-            it.identifier == BookmarksWorker.IDENTIFIER
-        } ?: return
         val workInfoLiveData = workManager.getWorkInfosForUniqueWorkLiveData(
-            validWorkRequest.identifier
+            BookmarksWorker.IDENTIFIER
         )
         workInfoLiveData.observe(lifecycleOwner) {
             if (it.isEmpty()) {

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
@@ -1,16 +1,43 @@
 package me.tylerbwong.stack.data.work
 
+import androidx.lifecycle.LifecycleOwner
 import androidx.work.WorkManager
-import androidx.work.WorkRequest
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class WorkScheduler @Inject constructor(
     private val workManager: WorkManager,
-    private val workRequests: Set<@JvmSuppressWildcards WorkRequest>
+    private val workRequests: Set<@JvmSuppressWildcards Work<*>>
 ) {
-    fun schedule() {
-        workRequests.forEach { workManager.enqueue(it) }
+    /**
+     * We only want uniquely identified work to run. If the first uniquely identifiable work is not
+     * present or currently enqueued, cancel all pending work before scheduling new work.
+     *
+     * @param lifecycleOwner The host [LifecycleOwner] that will be in charge of observing work info
+     * requests.
+     */
+    fun schedule(lifecycleOwner: LifecycleOwner) {
+        val validWorkRequest = workRequests.firstOrNull() ?: return
+        val workInfoLiveData = workManager.getWorkInfosForUniqueWorkLiveData(
+            validWorkRequest.identifier
+        )
+        workInfoLiveData.observe(lifecycleOwner) {
+            if (it.isEmpty()) {
+                workManager.cancelAllWork()
+            }
+            scheduleNewWork()
+        }
+    }
+
+    private fun scheduleNewWork() {
+        workRequests.forEach {
+            when (it) {
+                is Work.OneTime -> workManager
+                    .enqueueUniqueWork(it.identifier, it.existingWorkPolicy, it.workRequest)
+                is Work.Periodic -> workManager
+                    .enqueueUniquePeriodicWork(it.identifier, it.existingWorkPolicy, it.workRequest)
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/data/work/WorkScheduler.kt
@@ -11,8 +11,8 @@ class WorkScheduler @Inject constructor(
     private val workRequests: Set<@JvmSuppressWildcards Work<*>>
 ) {
     /**
-     * We only want uniquely identified work to run. If the first uniquely identifiable work is not
-     * present or currently enqueued, cancel all pending work before scheduling new work.
+     * We only want uniquely identified work to run. If there is no pending work that is identified
+     * by [BookmarksWorker.IDENTIFIER], cancel all pending work before scheduling new work.
      *
      * @param lifecycleOwner The host [LifecycleOwner] that will be in charge of observing work info
      * requests.

--- a/app/src/main/kotlin/me/tylerbwong/stack/ui/MainActivity.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/ui/MainActivity.kt
@@ -109,7 +109,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(
         }
 
         appUpdater.checkForUpdate(this)
-        workScheduler.schedule()
+        workScheduler.schedule(this)
         populateContent(savedInstanceState)
     }
 

--- a/app/src/main/kotlin/me/tylerbwong/stack/ui/questions/detail/QuestionDetailMainViewModel.kt
+++ b/app/src/main/kotlin/me/tylerbwong/stack/ui/questions/detail/QuestionDetailMainViewModel.kt
@@ -6,9 +6,7 @@ import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import me.tylerbwong.stack.R
 import me.tylerbwong.stack.api.model.Question
 import me.tylerbwong.stack.api.model.Response
@@ -122,24 +120,28 @@ class QuestionDetailMainViewModel @ViewModelInject constructor(
         toggleAction(
             isSelected,
             {
-                val response = service.favoriteQuestionById(it)
-                withContext(Dispatchers.IO) {
-                    val question = response.items.firstOrNull()
-                    if (question != null) {
-                        questionRepository.saveQuestion(question)
-                    }
-                }
-                response
+                // TODO Enable Offline
+//                val response = service.favoriteQuestionById(it)
+//                withContext(Dispatchers.IO) {
+//                    val question = response.items.firstOrNull()
+//                    if (question != null) {
+//                        questionRepository.saveQuestion(question)
+//                    }
+//                }
+//                response
+                service.favoriteQuestionById(it)
             },
             {
-                val response = service.undoQuestionFavoriteById(it)
-                withContext(Dispatchers.IO) {
-                    val question = response.items.firstOrNull()
-                    if (question != null) {
-                        questionRepository.removeQuestion(question)
-                    }
-                }
-                response
+                // TODO Enable Offline
+//                val response = service.undoQuestionFavoriteById(it)
+//                withContext(Dispatchers.IO) {
+//                    val question = response.items.firstOrNull()
+//                    if (question != null) {
+//                        questionRepository.removeQuestion(question)
+//                    }
+//                }
+//                response
+                service.undoQuestionFavoriteById(it)
             }
         )
     }

--- a/app/src/test/kotlin/me/tylerbwong/stack/data/repository/QuestionRepositoryTest.kt
+++ b/app/src/test/kotlin/me/tylerbwong/stack/data/repository/QuestionRepositoryTest.kt
@@ -17,9 +17,11 @@ import me.tylerbwong.stack.data.persistence.dao.UserDao
 import me.tylerbwong.stack.data.persistence.entity.QuestionEntity
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.Mock
 
+@Ignore("Re-enable once offline is enabled")
 class QuestionRepositoryTest : BaseTest() {
 
     @Mock


### PR DESCRIPTION
#### Description
Fixes #93.

Background work was not being enqueued as unique work. This meant that every time a user opened the app, a new set of `WorkRequest`s would get enqueued, but existing work requests would not be canceled. This was especially noticeable with `BookmarksWorker`, which is a `PeriodicWorkRequest` that ran every 8 hours. Every time a user opened the app, a new request would be scheduled to be run every 8 hours from that point.

The side-effects of this bug would be that work requests would compound and eventually attempt to make a large number of requests to the Stack Exchange API at once. This would result in 503s being returned and the "Network error" message to appear when making any API request.

This PR introduces a fix going forward that will check `WorkManager` for existing work based on new identifiers on each `WorkRequest`. If no currently enqueued work is found for any new identifier, cancel all `WorkRequests` since we can assume the user has a ton of non-unique work enqueued. Then schedule the unique work as normal (based on the `ExistingWorkPolicy`).

This overall disables offline bookmarks for now until a more sustainable solution is developed.

#### Checklist
- [x] I self reviewed the submitted code
- [x] I ran `./gradlew ktlintCheck detekt` before submitting this PR
- [x] I ran the app on a device/emulator or added unit tests to verify this change
