### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Run Static Analysis
         run: ./gradlew ktlintCheck detekt
@@ -23,10 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Check Compatibility
         run: ./gradlew metalavaCheckCompatibilityRelease
@@ -35,10 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest testBaseDebugUnitTest
@@ -49,7 +52,7 @@ jobs:
           find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} junit/ \;
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: junit-results
           path: junit
@@ -59,10 +62,11 @@ jobs:
 #    runs-on: macos-latest
 #    timeout-minutes: 30
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: set up JDK 17
-#        uses: actions/setup-java@v1
+#        uses: actions/setup-java@v3
 #        with:
+#          distribution: 'zulu'
 #          java-version: 17
 #      - name: Run Integration Tests
 #        uses: reactivecircus/android-emulator-runner@v2
@@ -73,7 +77,7 @@ jobs:
 #          script: ./gradlew connectedBaseDebugAndroidTest
 #      - name: Upload Test Results
 #        if: always()
-#        uses: actions/upload-artifact@v1
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: integration-results
 #          path: app/build/reports/androidTests/connected/flavors/base
@@ -82,10 +86,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Run Build
         run: ./gradlew assembleBaseDebug
@@ -94,10 +99,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set Up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: 17
       - name: Run Build
         run: ./gradlew assemblePlayDebug


### PR DESCRIPTION
#### Description
This updates all GitHub Actions being used to their latest majors - there shouldn't be anything breaking as they're mostly about using later versions of Node; though it sounds like the Java action might be a bit faster now due to smarter caching for downloading the JDK?

#### Checklist
- [x] I self reviewed the submitted code
- [x] I ran `./gradlew ktlintCheck detekt` before submitting this PR
- [x] I ran the app on a device/emulator or added unit tests to verify this change
