### PR TITLE
ci: increase job timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   static-analysis:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK 17
@@ -22,7 +22,7 @@ jobs:
 
   check-compatibility:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK 17
@@ -35,7 +35,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK 17
@@ -84,7 +84,7 @@ jobs:
 
   build-base:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK 17
@@ -97,7 +97,7 @@ jobs:
 
   build-play:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK 17


### PR DESCRIPTION
#### Description
It might be because of #146, but some jobs are sometimes taking longer than 10 minutes to build.

#### Checklist
- [x] I self reviewed the submitted code
- [x] I ran `./gradlew ktlintCheck detekt` before submitting this PR
- [x] I ran the app on a device/emulator or added unit tests to verify this change
