### PR TITLE
Avoid bundling `PreviewActivity`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,7 +98,8 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // google
     playImplementation(platform(libs.google.firebase.bom))

--- a/compose-markdown-demo/build.gradle.kts
+++ b/compose-markdown-demo/build.gradle.kts
@@ -25,7 +25,8 @@ dependencies {
     // compose
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // markdown
     implementation(projects.composeMarkdown)

--- a/compose-markdown/build.gradle.kts
+++ b/compose-markdown/build.gradle.kts
@@ -32,7 +32,8 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // markdown
     implementation(libs.jetbrains.markdown)

--- a/compose-preference/build.gradle.kts
+++ b/compose-preference/build.gradle.kts
@@ -30,7 +30,8 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     androidTestImplementation(libs.androidx.compose.ui.test)
     androidTestImplementation(libs.androidx.test.core.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ androidx-compose-material-icons-extended = { module = "androidx.compose.material
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidx-compose-material3" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
 androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose-ui" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }


### PR DESCRIPTION
#### Description

Run `diffuse diff app-base-release-unsigned-before.apk app-base-release-unsigned-after.apk > diff.txt`:

```
OLD: app-base-release-unsigned-before.apk (signature: none)
NEW: app-base-release-unsigned-after.apk (signature: none)

          │            compressed             │            uncompressed
          ├───────────┬───────────┬───────────┼───────────┬───────────┬────────────
 APK      │ old       │ new       │ diff      │ old       │ new       │ diff
──────────┼───────────┼───────────┼───────────┼───────────┼───────────┼────────────
      dex │   3.3 MiB │   3.3 MiB │ -51.4 KiB │     8 MiB │   7.9 MiB │ -122.8 KiB
     arsc │   1.4 MiB │   1.4 MiB │       0 B │   1.4 MiB │   1.4 MiB │        0 B
 manifest │   4.4 KiB │   4.3 KiB │     -54 B │    21 KiB │  20.8 KiB │     -192 B
      res │ 525.3 KiB │ 525.2 KiB │     -89 B │ 829.2 KiB │   828 KiB │   -1.2 KiB
    asset │   359 KiB │ 358.8 KiB │    -147 B │ 839.7 KiB │ 839.5 KiB │     -147 B
    other │  82.6 KiB │  82.3 KiB │    -366 B │  97.4 KiB │  97.4 KiB │      -12 B
──────────┼───────────┼───────────┼───────────┼───────────┼───────────┼────────────
    total │   5.7 MiB │   5.7 MiB │ -52.1 KiB │  11.2 MiB │  11.1 MiB │ -124.3 KiB

         │         raw          │                unique
         ├───────┬───────┬──────┼───────┬───────┬──────────────────────
 DEX     │ old   │ new   │ diff │ old   │ new   │ diff
─────────┼───────┼───────┼──────┼───────┼───────┼──────────────────────
   files │     2 │     2 │    0 │       │       │
 strings │ 36632 │ 36291 │ -341 │ 33911 │ 33571 │ -340 (+3730 -4070)
   types │ 14903 │ 14712 │ -191 │ 13673 │ 13482 │ -191 (+3727 -3918)
 classes │ 12278 │ 12089 │ -189 │ 12278 │ 12089 │ -189 (+3595 -3784)
 methods │ 76672 │ 75855 │ -817 │ 74550 │ 73733 │ -817 (+30487 -31304)
  fields │ 33245 │ 32622 │ -623 │ 32692 │ 32069 │ -623 (+13048 -13671)

 ARSC    │ old  │ new  │ diff
─────────┼──────┼──────┼──────
 configs │  237 │  237 │  0
 entries │ 5896 │ 5896 │  0

=================
====   APK   ====
=================

      compressed       │     uncompressed      │
───────────┬───────────┼──────────┬────────────┤
 size      │ diff      │ size     │ diff       │ path
───────────┼───────────┼──────────┼────────────┼────────────────────────────────────────────────────────
   2.7 MiB │   -51 KiB │  6.6 MiB │ -122.8 KiB │ ∆ classes.dex
  40.5 KiB │ +40.5 KiB │ 40.4 KiB │  +40.4 KiB │ + qd/a.gz
           │ -40.5 KiB │          │  -40.4 KiB │ - rd/a.gz
 547.8 KiB │    -426 B │  1.3 MiB │      +40 B │ ∆ classes2.dex
           │    -188 B │          │       -6 B │ - META-INF/androidx.compose.ui_ui-tooling-data.version
           │    -178 B │          │       -6 B │ - META-INF/androidx.compose.ui_ui-tooling.version
   9.2 KiB │    -140 B │  9.1 KiB │     -140 B │ ∆ assets/dexopt/baseline.prof
     129 B │    +129 B │      5 B │       +5 B │ + META-INF/services/da.g0
           │    -129 B │          │       -5 B │ - META-INF/services/ea.g0
     127 B │    +127 B │      5 B │       +5 B │ + META-INF/services/ia.u
           │    -127 B │          │       -5 B │ - META-INF/services/ja.u
  12.9 KiB │     -83 B │ 96.3 KiB │   -1.2 KiB │ ∆ res/M7.json
   4.3 KiB │     -54 B │ 20.8 KiB │     -192 B │ ∆ AndroidManifest.xml
   1.1 KiB │      -7 B │    946 B │       -7 B │ ∆ assets/dexopt/baseline.profm
     377 B │      -4 B │    281 B │        0 B │ ∆ res/-B.png
     163 B │      -2 B │     67 B │        0 B │ ∆ res/MD.png
───────────┼───────────┼──────────┼────────────┼────────────────────────────────────────────────────────
   3.3 MiB │ -52.1 KiB │  8.1 MiB │ -124.3 KiB │ (total)

======================
====   MANIFEST   ====
======================

@@ -437,6 +437,2 @@
         />
-    <activity
-        android:exported="true"
-        android:name="androidx.compose.ui.tooling.PreviewActivity"
-        />
     <service
```

#### Checklist
- [x] I self reviewed the submitted code
- [x] I ran `./gradlew ktlintCheck detekt` before submitting this PR
- [x] I ran the app on a device/emulator or added unit tests to verify this change
